### PR TITLE
Update the confusing title

### DIFF
--- a/release-priority-labels.md
+++ b/release-priority-labels.md
@@ -1,4 +1,4 @@
-- Feature Name: release-label-improvements
+- Feature Name: severity-label-improvements
 - Start Date: 2020-01-13
 - SEP Status: Draft
 - SEP PR: https://github.com/saltstack/salt-enhancement-proposals/pull/24


### PR DESCRIPTION
Originally, we use to call the priority and severity labels "release priority" labels and this title is confusing on the SEP as all it addressed was combining the severity labels to include the number of users affected (as the P1-4 labels did in the past) and make the labels close to well-known, industry standards.